### PR TITLE
Feature/nex 64 define browserslist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# browserlist-config-desktop
-Shareable Desktops Browserslist config
+# browserlist-config-tao
+
+Shareable _Browserslist_ for TAO
+
+## Usage
+
+This configuration can be used by all the tools that supports [browserslist](https://github.com/browserslist/browserslist) : Babel, Autoprefixer, eslint-plugin-compat, etc.
+
+Add this package in your dependencies : 
+
+```
+npm install --save-dev @oat-sa/browserlist-config-tao
+```
+
+Then in your `package.json` :
+```js
+{
+    "browserslist" : [
+        "extends @oat-sa/browserslist-config-tao"
+    ]
+}
+```
+
+## Display the supported browsers
+
+From this repository : 
+```
+npm run browserslist
+```
+
+From your repository : 
+
+```
+npx browserslist
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# browserlist-config-tao
+# browserslist-config-tao
 
 Shareable _Browserslist_ for TAO
 
@@ -9,7 +9,7 @@ This configuration can be used by all the tools that supports [browserslist](htt
 Add this package in your dependencies : 
 
 ```
-npm install --save-dev @oat-sa/browserlist-config-tao
+npm install --save-dev @oat-sa/browserslist-config-tao
 ```
 
 Then in your `package.json` :

--- a/index.js
+++ b/index.js
@@ -1,0 +1,36 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA;
+ */
+
+/**
+ * The shared supported browsers by TAO :
+ *  - last 2 versions of Chrome, Firefox, Edge and Safari
+ *  - last 2 version of Chrome and Firefox for Android, and iOS browsers
+ *  - IE 11
+ * See https://www.taotesting.com/get-tao/system-requirements/
+ * See hhttps://github.com/browserslist/browserslist#shareable-configs
+ */
+module.exports = [
+    'last 2 chrome versions',
+    'last 2 and_chr versions',
+    'last 2 and_ff versions',
+    'last 2 firefox versions',
+    'last 2 ios versions',
+    'last 2 safari versions',
+    'last 2 edge versions',
+    'ie 11'
+];

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@
  *  - last 2 version of Chrome and Firefox for Android, and iOS browsers
  *  - IE 11
  * See https://www.taotesting.com/get-tao/system-requirements/
- * See hhttps://github.com/browserslist/browserslist#shareable-configs
+ * See https://github.com/browserslist/browserslist#shareable-configs
  */
 module.exports = [
     'last 2 chrome versions',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,46 @@
+{
+    "name": "@oat-sa/browserlist-config-desktop",
+    "version": "0.1.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "browserslist": {
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+            "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30000960",
+                "electron-to-chromium": "^1.3.124",
+                "node-releases": "^1.1.14"
+            }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000963",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+            "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+            "dev": true
+        },
+        "electron-to-chromium": {
+            "version": "1.3.125",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
+            "integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
+            "dev": true
+        },
+        "node-releases": {
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+            "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+            "dev": true,
+            "requires": {
+                "semver": "^5.3.0"
+            }
+        },
+        "semver": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@oat-sa/browserlist-config-tao",
+    "version": "0.1.0",
+    "description": "Shareable Browserslist config for TAO",
+    "main": "index.js",
+    "scripts": {
+        "browserslist": "node query.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/oat-sa/browserlist-config-tao.git"
+    },
+    "keywords": [
+        "browserslist",
+        "oat",
+        "tao",
+        "desktop"
+    ],
+    "author": {
+        "name": "Bertrand Chevrier",
+        "email": "bertrand@taotesting.com",
+        "url": "https://taotesting.com"
+    },
+    "license": "GPL-2.0-only",
+    "bugs": {
+        "url": "https://github.com/oat-sa/browserlist-config-tao/issues"
+    },
+    "homepage": "https://github.com/oat-sa/browserlist-config-tao#readme",
+    "publishConfig": {
+        "access": "public"
+    },
+    "devDependencies": {
+        "browserslist": "^4.5.5"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@oat-sa/browserlist-config-tao",
+    "name": "@oat-sa/browserslist-config-tao",
     "version": "0.1.0",
     "description": "Shareable Browserslist config for TAO",
     "main": "index.js",
@@ -8,7 +8,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/oat-sa/browserlist-config-tao.git"
+        "url": "git+https://github.com/oat-sa/browserslist-config-tao.git"
     },
     "keywords": [
         "browserslist",
@@ -23,9 +23,9 @@
     },
     "license": "GPL-2.0-only",
     "bugs": {
-        "url": "https://github.com/oat-sa/browserlist-config-tao/issues"
+        "url": "https://github.com/oat-sa/browserslist-config-tao/issues"
     },
-    "homepage": "https://github.com/oat-sa/browserlist-config-tao#readme",
+    "homepage": "https://github.com/oat-sa/browserslist-config-tao#readme",
     "publishConfig": {
         "access": "public"
     },

--- a/query.js
+++ b/query.js
@@ -1,0 +1,26 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA;
+ */
+
+/**
+ * Displays the current list of supported browsers
+ */
+const browserslist = require('browserslist');
+const queries = require('./index.js');
+const browsers = browserslist(queries);
+
+console.log(browsers.join('\n'));


### PR DESCRIPTION
Linked to https://oat-sa.atlassian.net/browse/NEX-78

Since we will leverage the tooling that uses https://github.com/browserslist/browserslist (Babel, Autoprefixer, etc.) into TAO Curgen and Nextgen, as well as side projects, we will share the supported list of browsers using the Browserslist format with a shared package.

Please see https://github.com/browserslist/browserslist#shareable-configs