### PR TITLE
Breaking/remove ie11 support and extend mobile support

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ module.exports = [
     'last 2 and_chr versions',
     'last 2 and_ff versions',
     'last 2 firefox versions',
-    'last 2 ios versions',
-    'last 2 safari versions',
-    'last 2 edge versions'
+    'last 2 ios major versions',
+    'last 2 safari major versions',
+    'last 2 edge versions',
+    'not dead'
 ];

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@
  * The shared supported browsers by TAO :
  *  - last 2 versions of Chrome, Firefox, Edge and Safari
  *  - last 2 version of Chrome and Firefox for Android, and iOS browsers
- *  - IE 11
  * See https://www.taotesting.com/get-tao/system-requirements/
  * See https://github.com/browserslist/browserslist#shareable-configs
  */
@@ -31,6 +30,5 @@ module.exports = [
     'last 2 firefox versions',
     'last 2 ios versions',
     'last 2 safari versions',
-    'last 2 edge versions',
-    'ie 11'
+    'last 2 edge versions'
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,38 +1,32 @@
 {
     "name": "@oat-sa/browserslist-config-tao",
-    "version": "0.3.1",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "browserslist": {
-            "version": "4.16.6",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+            "version": "4.20.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+            "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001219",
-                "colorette": "^1.2.2",
-                "electron-to-chromium": "^1.3.723",
+                "caniuse-lite": "^1.0.30001317",
+                "electron-to-chromium": "^1.4.84",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.71"
+                "node-releases": "^2.0.2",
+                "picocolors": "^1.0.0"
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001235",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
-            "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
-            "dev": true
-        },
-        "colorette": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+            "version": "1.0.30001325",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
+            "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.749",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
-            "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
+            "version": "1.4.106",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
+            "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
             "dev": true
         },
         "escalade": {
@@ -42,9 +36,15 @@
             "dev": true
         },
         "node-releases": {
-            "version": "1.1.72",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
-            "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+            "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+            "dev": true
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/browserslist-config-tao",
-    "version": "0.3.1",
+    "version": "1.0.0",
     "description": "Shareable Browserslist config for TAO",
     "main": "index.js",
     "scripts": {
@@ -30,6 +30,6 @@
         "access": "public"
     },
     "devDependencies": {
-        "browserslist": "^4.16.6"
+        "browserslist": "^4.20.2"
     }
 }


### PR DESCRIPTION
Preparation PR to update the list of supported browsers with:
 - IE 11  removal 
 - extend the ios versions to last 2 major versions 