### PR TITLE
Fix/disable Safari + iOS under 17.4

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,39 @@
+name: Release NPM package
+
+on:
+    pull_request:
+        branches:
+            - develop
+        types: [closed]
+
+jobs:
+    auto-release:
+        if: github.event.pull_request.merged == true
+        name: Automated package release
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Clone the repository
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0 #avoid unrelated history error
+                  token: ${{ secrets.SEMVER_GH_TOKEN }} #bypass branch protection rule
+
+            - name: Configure git user
+              #configuring git for runner
+              run: |
+                  git config --global user.name "oat-github-bot"
+                  git config --global user.email "oat-github-bot@taotesting.com"
+
+            - name: Install and apply the release tool
+              env:
+                  GITHUB_TOKEN: ${{ secrets.SEMVER_GH_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_RELEASE_TOKEN }}
+              run: |
+                  # setup the place
+                  npm config set //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+                  npm i -g @oat-sa/tao-extension-release
+                  # install the package
+                  npm ci
+                  #create tag and release a new version
+                  taoRelease npmRelease --no-interactive

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = [
     'last 2 ios major versions',
     'last 2 safari major versions',
     'last 2 edge versions',
-    'not safari <= 17.4',
-    'not ios <= 17.4',
+    'not safari < 17.4',
+    'not ios < 17.4',
     'not dead'
 ];

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 Open Assessment Technologies SA;
+ * Copyright (c) 2019-2025 Open Assessment Technologies SA;
  */
 
 /**
@@ -31,5 +31,7 @@ module.exports = [
     'last 2 ios major versions',
     'last 2 safari major versions',
     'last 2 edge versions',
+    'not safari <= 17.4',
+    'not ios <= 17.4',
     'not dead'
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,51 +1,132 @@
 {
-  "name": "@oat-sa/browserslist-config-tao",
-  "version": "1.0.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
-      }
-    },
-    "caniuse-lite": {
-      "version": "1.0.30001367",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
-      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
-      "dev": true
-    },
-    "electron-to-chromium": {
-      "version": "1.4.106",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-      "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
-      "dev": true
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
-    },
-    "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+    "name": "@oat-sa/browserslist-config-tao",
+    "version": "1.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@oat-sa/browserslist-config-tao",
+            "version": "1.0.1",
+            "license": "GPL-2.0-only",
+            "devDependencies": {
+                "browserslist": "^4.24.5"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.24.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "caniuse-lite": "^1.0.30001716",
+                "electron-to-chromium": "^1.5.149",
+                "node-releases": "^2.0.19",
+                "update-browserslist-db": "^1.1.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001718",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+            "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.155",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
+            "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
         "access": "public"
     },
     "devDependencies": {
-        "browserslist": "^4.20.2"
+        "browserslist": "^4.24.5"
     }
 }


### PR DESCRIPTION
Based on common consensus, we'll stop supporting older Safari. (Safari 19 will be released in September 2025, so from then  on we will officially support either Safari 19+18, or we'll increase the range to 3 major versions to support 19+18+17 - to be verified later).

Test:
`npm ci`
`npm run browserslist`

Query playground I based this on: [browsersl.ist](https://browsersl.ist/#q=++++last+2+chrome+versions%2C%0A++++last+2+and_chr+versions%2C%0A++++last+2+and_ff+versions%2C%0A++++last+2+firefox+versions%2C%0A++++last+2+ios+major+versions%2C%0A++++last+2+safari+major+versions%2C%0A++++last+2+edge+versions%2C%0A++++not+safari+%3C+17.4%2C%0A++++not+ios+%3C+17.4%2C%0A++++not+dead%0A)